### PR TITLE
Add Node engine to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "sass": "sass --watch src/style/sass:src/style/css"
   },
   "engines": {
+    "node": "12.4.0",
     "yarn": "1.16.0"
   },
   "dependencies": {


### PR DESCRIPTION
- Heroku emitting Error R10 Boot timeout: web process failed to bind to $PORT
- Checking whether Heroku is not binding to Node because version not defined
- Relates #125